### PR TITLE
replaces call to deprecated function download_as_dataformat() with supported equivalent.

### DIFF
--- a/dbexport.php
+++ b/dbexport.php
@@ -26,7 +26,6 @@
 // Require libs.
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 require_once($CFG->libdir.'/adminlib.php');
-require_once($CFG->libdir.'/dataformatlib.php');
 require_once($CFG->dirroot.'/plagiarism/turnitin/classes/turnitin_view.class.php');
 
 $cssurl = new moodle_url('/plagiarism/turnitin/styles.css');
@@ -64,7 +63,7 @@ if (!is_null($table)) {
         $data = $DB->get_records($table, null, 'id ASC');
 
         // Use Moodle's dataformatting functions to output the data in the desired format.
-        download_as_dataformat($exportfile, $dataformat, array_keys($DB->get_columns($table)), $data);
+        \core\dataformat::download_data($exportfile, $dataformat, array_keys($DB->get_columns($table)), $data);
         exit;
 
     } else {


### PR DESCRIPTION
for reference, this is a patched commit
https://github.com/turnitin/moodle-plagiarism_turnitin/commit/692ee215cc678361ba440a4421c5fbbfff687ba from upstream.

please see  https://tracker.moodle.org/browse/MDL-80409 for further info.